### PR TITLE
サーバーモードの高速化について

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -82,29 +82,35 @@ jum_text <- function (input, server = FALSE) {
 
   # input command
   if(server == TRUE) {
-    pid <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $2}'",
-                  intern = TRUE)
-    if(length(pid) == 0) {
-      stop("JUMAN++ server is not running.")
+    if ("server_host" %in% ls(.options) &&
+        "server_port" %in% ls(.options)) {
+      host <- .options$server_host
+      port <- .options$server_post
+    } else {
+      pid <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $2}'",
+                    intern = TRUE)
+      if(length(pid) == 0) {
+        stop("JUMAN++ server is not running.")
+      }
+
+      hostn <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $15}'",
+                      intern = TRUE)
+      if(identical(hostn, "")) {
+        host <- ""
+      } else {
+        host <- paste("--host", hostn)
+      }
+
+      portn <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $18}'",
+                      intern = TRUE)
+      if(identical(portn, "")) {
+        port <- ""
+      } else {
+        port <- paste("--host", portn)
+      }
     }
 
     rb_client <- system.file("ruby/client.rb", package = "rjumanpp")
-
-    hostn <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $15}'",
-                   intern = TRUE)
-    if(identical(hostn, "")) {
-      host <- ""
-    } else {
-      host <- paste("--host", hostn)
-    }
-
-    portn <- system("ps -aefw | grep 'ruby/server.rb' | grep -v ' grep ' | awk '{print $18}'",
-                    intern = TRUE)
-    if(identical(portn, "")) {
-      port <- ""
-    } else {
-      port <- paste("--host", portn)
-    }
 
     command <- paste("echo", input, "| ruby", rb_client, host, port)
   } else {

--- a/R/server.R
+++ b/R/server.R
@@ -46,6 +46,9 @@ jum_start_server <- function(host.name = NULL, port = NULL) {
                           "&")
   system(server_command)
 
+  # Register Server Information ---------------------------------------------
+  .options$server_host <- host
+  .options$server_port <- port
 }
 
 ##' Close JUMAN++ server.

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -3,3 +3,10 @@
   if (is.null(whichjuman)) {stop("JUMAN++ is NOT installed. Please install it.")}
   packageStartupMessage("This package depends on JUMAN++ 1.02")
 }
+
+.onLoad <- function(libname, pkgname) {
+  # Create Option Environment -----------------------------------------------
+  package_option_env <- new.env(parent = emptyenv())
+  package_namespace <- asNamespace(pkgname)
+  assign(".options", package_option_env, envir = package_namespace)
+}


### PR DESCRIPTION
素晴らしいパッケージをありがとうございます。
大変便利に使わせていただいております。

さて、jum_text() を高速に実行したいと思い、サーバーモードにて利用しましたところ、思うより速度が上がりませんでした。
実行例を示します。

```r
# devtools::install_github("ymattu/rjumanpp")

text <- "外国人参政権に対する考え方の違い。"

library(rjumanpp)

jum_start_server()

library(microbenchmark)
mb <- microbenchmark(times = 10,
  `server=FALSE` = jum_text(text, server = FALSE),
  `server=TRUE`  = jum_text(text, server = TRUE)
)
print(mb, digits=0)
```

```
Unit: milliseconds
         expr min  lq mean median  uq  max neval
 server=FALSE 344 348  353    352 359  365    10
  server=TRUE 248 256  556    518 751 1250    10
```

こちら原因として `server=TRUE` の時に host name と port number を system() を使って毎回取得しているためではないかと思います。

解決案の一つとして、パッケージ内にオプション環境を定義して、jum_start_server() 時にこれら保存する方法が考えられます。
このプルリクエストはその実装例です。

私の環境では上記コードの実行結果は次のように変わりました。

```
nit: milliseconds
         expr min  lq mean median  uq max neval
 server=FALSE 345 355  357    358 362 373    10
  server=TRUE 125 128  132    129 130 164    10
```

お役に立てれば幸いです。